### PR TITLE
Feature/restrict expiry with maxlength

### DIFF
--- a/src/payform.coffee
+++ b/src/payform.coffee
@@ -332,8 +332,8 @@
 
     value = e.target.value + digit
     value = value.replace(/\D/g, '')
-    maxlength = e.target.getAttribute('data-maxlength')
-    restrictValue = if typeof maxlength == "number" then maxlength else 6
+    maxlength = parseInt(e.target.getAttribute('data-maxlength'), 10)
+    restrictValue = if typeof maxlength == "number" and !isNaN(maxlength) then maxlength else 6
 
     if value.length > restrictValue
       e.preventDefault()

--- a/src/payform.coffee
+++ b/src/payform.coffee
@@ -332,8 +332,10 @@
 
     value = e.target.value + digit
     value = value.replace(/\D/g, '')
+    maxlength = e.target.getAttribute('data-maxlength')
+    restrictValue = if typeof maxlength == "number" then maxlength else 6
 
-    if value.length > 6
+    if value.length > restrictValue
       e.preventDefault()
 
   restrictCVC = (e) ->


### PR DESCRIPTION
update restrictExpiry method to accept an override value from an html element data attribute 'data-maxlength'. Nmp tests run green and I didn't see any specific tests on this method so I didn't bother with a new test.

Reason:
I wanted to restrict it to 4 digits MMYY. The parseCardExpiry method allowed for 2 digits for year but the restrictExpiry method did not. I started with just using maxlength on the html input but felt it better to use a data attribute instead. Its possible the formatter could change from " / " to something else in which case the html input would have an incorrect maxlength attribute.