### PR TITLE
Listening for `input` events is sufficient

### DIFF
--- a/javascripts/form.js
+++ b/javascripts/form.js
@@ -10,10 +10,7 @@
   payform.expiryInput(expiry);
   payform.cvcInput(cvc);
 
-  ccnum.addEventListener('keydown', updateType);
-  ccnum.addEventListener('paste',   updateType);
   ccnum.addEventListener('input',   updateType);
-  ccnum.addEventListener('change',  updateType);
 
   submit.addEventListener('click', function() {
     var valid     = [],


### PR DESCRIPTION
There’s no reason to listen to `keydown`, `paste`, or `change` events individually. `input` covers all of them and is supported in all modern browsers (including IE9+).

https://mathiasbynens.be/notes/oninput