### PR TITLE
Take Diner's Club non-default formatting into consideration

### DIFF
--- a/src/payform.coffee
+++ b/src/payform.coffee
@@ -212,8 +212,8 @@
     cursor = _getCaretPos(e.target)
     return if cursor and cursor isnt value.length
 
-    if card && card.type is 'amex'
-      # AMEX cards are formatted differently
+    if card && card.type in ['amex', 'dinersclub']
+      # AMEX and Diner's Club cards are formatted differently
       re = /^(\d{4}|\d{4}\s\d{6})$/
     else
       re = /(?:^|\s)(\d{4})$/


### PR DESCRIPTION
Diner's Club cards have a custom format defined in `cards`. However, in `formatCardNumber` the default format is being used for this type which causes the following observed issues:
- After entering the first 8 digits, the cursor is moved ahead a space ie. "xxxx xxxx "
- After entering the first 11 digits, the cursor is moved backwards to be in front of the last digit. This causes any subsequent digits entered to be out of order.

This issue was mentioned in https://github.com/jondavidjohn/payform/issues/19 by @mcarson-123

This commit updates `formatCardNumber` to handle Diner's Club cards the same way as AMEX cards when appending the next digit.