### PR TITLE
Use property definition to normalize read-only event target and which

### DIFF
--- a/src/payform.coffee
+++ b/src/payform.coffee
@@ -29,8 +29,9 @@
 
   _eventNormalize = (listener) ->
     return (e = window.event) ->
-      e.target = e.target or e.srcElement
-      e.which = e.which or e.keyCode
+      Object.defineProperties e,
+        target: value: e.target or e.srcElement
+        which: value: e.which or e.keyCode
       unless e.preventDefault?
         e.preventDefault = -> this.returnValue = false
       listener(e)

--- a/src/payform.coffee
+++ b/src/payform.coffee
@@ -29,12 +29,21 @@
 
   _eventNormalize = (listener) ->
     return (e = window.event) ->
-      Object.defineProperties e,
-        target: value: e.target or e.srcElement
-        which: value: e.which or e.keyCode
-      unless e.preventDefault?
-        e.preventDefault = -> this.returnValue = false
-      listener(e)
+      if e.inputType == 'insertCompositionText' and !e.isComposing
+        return
+      newEvt =
+        target: e.target or e.srcElement
+        which: e.which or e.keyCode
+        type: e.type
+        metaKey: e.metaKey
+        ctrlKey: e.ctrlKey
+        preventDefault: ->
+          if e.preventDefault
+            e.preventDefault()
+          else
+            e.returnValue = false
+          return
+      listener(newEvt)
 
   _on = (ele, event, listener) ->
     listener = _eventNormalize(listener)


### PR DESCRIPTION
Fixes #37

The following snippets demonstrate the difference between property assignment and definition:

Property assignment (Issue):

[![Edit k1254pn7](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/k5rrn0k07v)

Property definition (Fix):
[![Edit define event properties fix](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/k1254pn7)
## Changes

- Use property definition instead of property assignment to normalize UI keyboard event properties (i.e. `target` and `which`) across major desktop browsers.

### Why introduce these changes?

- Allows `Payform` to be vendored with using ES6 imports
- Solve TypeErrors which were being raised (see #37 for more details).

### How is this achieved?

- ~~Normalize `target` and `which` KeyboardEvent properties definition through the [Object.defineProperty()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty) static method.~~

- Since we want to maintain our compatibility with IE8, we create a "synthetic" event object with the necessary properties used throughout `Payform`. 

### Additional Information

1. Section [10.2.1](http://www.ecma-international.org/ecma-262/6.0/#sec-strict-mode-code) of the official ES6 specification states that:
>Module code is always strict mode code.

This prevents [assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Read-only) of read-only properties.

2. How is property assignment different from property definition? Why does the former throws errors?

According to Dr. Axel Rauschmayer, there are noticeable [differences](http://2ality.com/2012/08/property-definition-assignment.html) between property definition and assignment. Specifically, when dealing with read-only properties such as `target`:

>Read-only properties in prototypes prevent assignment, but not definition. 