### PR TITLE
Add LTR mark for credit card and expiry payform fields

### DIFF
--- a/src/payform.coffee
+++ b/src/payform.coffee
@@ -200,6 +200,8 @@
   reFormatCardNumber = (e) ->
     return if e.target.value is ""
     e.target.value = payform.formatCardNumber(e.target.value)
+    if e.target.value.indexOf('‎\u200e') == -1 and document.dir == 'rtl'
+      e.target.value = '‎\u200e'.concat(e.target.value)
     cursor = _getCaretPos(e.target)
     if cursor? and e.type isnt 'change'
       e.target.setSelectionRange(cursor, cursor)
@@ -261,6 +263,8 @@
   reFormatExpiry = (e) ->
     return if e.target.value is ""
     e.target.value = payform.formatCardExpiry(e.target.value)
+    if e.target.value.indexOf('‎\u200e') == -1 and document.dir == 'rtl'
+      e.target.value = '‎\u200e'.concat(e.target.value)
     cursor = _getCaretPos(e.target)
     if cursor? and e.type isnt 'change'
       e.target.setSelectionRange(cursor, cursor)

--- a/src/payform.coffee
+++ b/src/payform.coffee
@@ -200,7 +200,7 @@
   reFormatCardNumber = (e) ->
     return if e.target.value is ""
     e.target.value = payform.formatCardNumber(e.target.value)
-    if e.target.value.indexOf('‎\u200e') == -1 and document.dir == 'rtl'
+    if document.dir == 'rtl' and e.target.value.indexOf('‎\u200e') == -1
       e.target.value = '‎\u200e'.concat(e.target.value)
     cursor = _getCaretPos(e.target)
     if cursor? and e.type isnt 'change'
@@ -263,7 +263,7 @@
   reFormatExpiry = (e) ->
     return if e.target.value is ""
     e.target.value = payform.formatCardExpiry(e.target.value)
-    if e.target.value.indexOf('‎\u200e') == -1 and document.dir == 'rtl'
+    if document.dir == 'rtl' and e.target.value.indexOf('‎\u200e') == -1 
       e.target.value = '‎\u200e'.concat(e.target.value)
     cursor = _getCaretPos(e.target)
     if cursor? and e.type isnt 'change'


### PR DESCRIPTION
Fixes #41

## Changes

- Make use of the [LTR mark](https://en.wikipedia.org/wiki/Left-to-right_mark) to set the way credit card values and expiry dates are displayed with respect to RTL direction.

- Typing this test AMEX credit card number `‎3782 822463 10005` will be displayed as is instead of `10005 822463 3782`.

### Why introduce these changes?

- Allow users to view expect RTL directionality behaviour in their applications.

### How is this achieved?

- Verify if an HTML right-to-left indicator exists and prepend the LTR mark `U+200E` to the target's value after setting the target element's value in the `reFormatCardNumber()` and `reFormatExpiry()` functions.

⚠️ For now, this fix will search for the global `dir` attribute. We could check for directionality within individual elements shall developers decide on specifying RTL on `<input>` elements instead of on`<html>`. (May change depending on if you feel comfortable deploying the suggested change on [event normalization](https://github.com/jondavidjohn/payform/pull/39)) ⚠️ 
