### PR TITLE
Ignore single digit removal when selection length is not equal to 1

### DIFF
--- a/src/payform.coffee
+++ b/src/payform.coffee
@@ -259,6 +259,8 @@
     cursor = _getCaretPos(e.target)
     return if cursor and cursor isnt value.length
 
+    return if (e.target.selectionEnd - e.target.selectionStart) > 1
+
     # Remove the digit + trailing space
     if /\d\s$/.test(value)
       e.preventDefault()


### PR DESCRIPTION
### Changes

Fixes #29 

### Why introduce these changes?

- Improve user experience by allowing removal of longer digit selections with mouse and `Crtl+A`.

### How is this achieved?

Given that a format is triggered by a `Backspace/Delete (key code 8)` key and that the selection length is not equal to 1, end function execution and ultimately ignore the following:

- Removal of single digit + trailing space
- Removal of single digit if input value ends in space + digit.