### PR TITLE
Clear control characters from expiry date string before parsing

### DIFF
--- a/src/payform.coffee
+++ b/src/payform.coffee
@@ -432,7 +432,7 @@
       prefix = prefix.toString()[0..1]
       year   = prefix + year
 
-    month = parseInt(month, 10)
+    month = parseInt(month.replace(/[\u200e]/g, ""), 10);
     year  = parseInt(year, 10)
 
     month: month, year: year

--- a/src/payform.coffee
+++ b/src/payform.coffee
@@ -432,6 +432,7 @@
       prefix = prefix.toString()[0..1]
       year   = prefix + year
 
+    # Remove left-to-right mark LTR invisible unicode control character used in right-to-left contexts
     month = parseInt(month.replace(/[\u200e]/g, ""), 10);
     year  = parseInt(year, 10)
 


### PR DESCRIPTION
### Changes

Fixes a parsing bug with the expiry field when typing in a RTL context. Since we are currently using a `u200e` control character to override the directionality of the card number and expiry date fields, it causes our month variable in `payform.parseCardExpiry` to return `NaN`.

```javascript
> const expiryString = '\u200e'.concat('12/21');
<- undefined
> const expiryValues = expiryString.split('/');
<- undefined
> expiryValues
<- (2) ["‎12", "21"]
> const month = parseInt(expiryValues[0], 10);
<- undefined
> month
<- NaN
```

### Why introduce these changes?

- It is currently not possible to obtain the month variable when using the exposed `payform.parseCardExpiry()` function in a RTL context.

### How is this achieved?

- Use the `replace()` function and a regex for `\u200e` to remove all its occurences from the string before it gets parsed.
- I double checked to make sure that this behaviour is not present with card numbers or the expiry year.