### PR TITLE
Reposition cursor when pasting full card numbers

### DIFF
--- a/src/payform.coffee
+++ b/src/payform.coffee
@@ -209,11 +209,20 @@
 
   reFormatCardNumber = (e) ->
     return if e.target.value is ""
+    if document.dir == 'ltr'
+      cursor = _getCaretPos(e.target)
+
     e.target.value = payform.formatCardNumber(e.target.value)
+
+    if document.dir == 'ltr' and cursor isnt e.target.selectionStart
+      cursor = _getCaretPos(e.target)
+
     if document.dir == 'rtl' and e.target.value.indexOf('‎\u200e') == -1
       e.target.value = '‎\u200e'.concat(e.target.value)
+
     cursor = _getCaretPos(e.target)
-    if cursor? and e.type isnt 'change'
+    
+    if cursor? and cursor isnt 0 and e.type isnt 'change'
       e.target.setSelectionRange(cursor, cursor)
 
   formatCardNumber = (e) ->

--- a/src/payform.coffee
+++ b/src/payform.coffee
@@ -167,6 +167,14 @@
   cardFromType = (type) ->
     return card for card in payform.cards when card.type is type
 
+  getDirectionality = (target) ->
+    # Work around Firefox not returning the styles in some edge cases.
+    # In Firefox < 62, style can be `null`.
+    # In Firefox 62+, `style['direction']` can be an empty string.
+    # See https://bugzilla.mozilla.org/show_bug.cgi?id=1467722.
+    style = getComputedStyle(target)
+    style and style['direction'] or document.dir
+
   luhnCheck = (num) ->
     odd = true
     sum = 0
@@ -209,15 +217,16 @@
 
   reFormatCardNumber = (e) ->
     return if e.target.value is ""
-    if document.dir == 'ltr'
+
+    if getDirectionality(e.target) == 'ltr'
       cursor = _getCaretPos(e.target)
 
     e.target.value = payform.formatCardNumber(e.target.value)
 
-    if document.dir == 'ltr' and cursor isnt e.target.selectionStart
+    if getDirectionality(e.target) == 'ltr' and cursor isnt e.target.selectionStart
       cursor = _getCaretPos(e.target)
 
-    if document.dir == 'rtl' and e.target.value.indexOf('‎\u200e') == -1
+    if getDirectionality(e.target) == 'rtl' and e.target.value.indexOf('‎\u200e') == -1
       e.target.value = '‎\u200e'.concat(e.target.value)
 
     cursor = _getCaretPos(e.target)
@@ -282,7 +291,7 @@
   reFormatExpiry = (e) ->
     return if e.target.value is ""
     e.target.value = payform.formatCardExpiry(e.target.value)
-    if document.dir == 'rtl' and e.target.value.indexOf('‎\u200e') == -1 
+    if getDirectionality(e.target) == 'rtl' and e.target.value.indexOf('‎\u200e') == -1 
       e.target.value = '‎\u200e'.concat(e.target.value)
     cursor = _getCaretPos(e.target)
     if cursor? and e.type isnt 'change'


### PR DESCRIPTION
### Changes

Resolves a couple of minor of issues when copy pasting full card numbers:

- When pasting a full length credit card, the cursor is not positioned at the very end, but instead, a few digits before. (e.g. pasting a (16) digit credit card will cause the cursor to be 3 digits before)

- When selecting a full length credit card, by mouse or keyboard, and then pasting again the same credit card number, it will add three extra numbers to the very end of it, resulting in a 19 digit card.

### Why introduce these changes?

- These cursor and pasting issues are re we plan to update our BIN regex patterns for our supported credit card numbers

### How is this achieved?

...